### PR TITLE
fix: Send a session id to handle better the events

### DIFF
--- a/packages/main/src/ipc.ts
+++ b/packages/main/src/ipc.ts
@@ -52,7 +52,7 @@ export async function downloadApp(event: Electron.IpcMainInvokeEvent, url: strin
             type: IPC_EVENT_DATA_TYPE.START,
             progress: 0,
           });
-          analytics.track(ANALYTICS_EVENT.DOWNLOAD_VERSION, { version });
+          analytics.track(ANALYTICS_EVENT.DOWNLOAD_VERSION, { version, os: getOSName() });
         },
         onProgress: progress => {
           event.sender.send(IPC_EVENTS.DOWNLOAD_STATE, {
@@ -64,7 +64,7 @@ export async function downloadApp(event: Electron.IpcMainInvokeEvent, url: strin
           try {
             event.sender.send(IPC_EVENTS.DOWNLOAD_STATE, { type: IPC_EVENT_DATA_TYPE.COMPLETED });
             event.sender.send(IPC_EVENTS.INSTALL_STATE, { type: IPC_EVENT_DATA_TYPE.START });
-            analytics.track(ANALYTICS_EVENT.INSTALL_VERSION_START, { version });
+            analytics.track(ANALYTICS_EVENT.INSTALL_VERSION_START, { version, os: getOSName() });
 
             await decompressFile(file.path, branchPath);
 
@@ -88,11 +88,11 @@ export async function downloadApp(event: Electron.IpcMainInvokeEvent, url: strin
             fs.writeFileSync(EXPLORER_VERSION_PATH, JSON.stringify(versionData));
 
             event.sender.send(IPC_EVENTS.INSTALL_STATE, { type: IPC_EVENT_DATA_TYPE.COMPLETED });
-            analytics.track(ANALYTICS_EVENT.INSTALL_VERSION_SUCCESS, { version });
+            analytics.track(ANALYTICS_EVENT.INSTALL_VERSION_SUCCESS, { version, os: getOSName() });
           } catch (error) {
             log.error('[Main Window][IPC][DownloadApp] Failed to install app:', error);
             event.sender.send(IPC_EVENTS.INSTALL_STATE, { type: IPC_EVENT_DATA_TYPE.ERROR, error });
-            analytics.track(ANALYTICS_EVENT.INSTALL_VERSION_ERROR, { version });
+            analytics.track(ANALYTICS_EVENT.INSTALL_VERSION_ERROR, { version, os: getOSName() });
           } finally {
             if (fs.existsSync(file.path)) {
               fs.rmSync(file.path);

--- a/packages/shared/src/analytics/index.ts
+++ b/packages/shared/src/analytics/index.ts
@@ -1,4 +1,5 @@
 import { Analytics as SegmentAnalytics } from '@segment/analytics-node';
+import { v4 as uuid } from 'uuid';
 import { type ANALYTICS_EVENTS } from './types';
 
 const APP_ID = 'decentraland-launcher';
@@ -13,6 +14,7 @@ export class Analytics {
   private analytics: SegmentAnalytics | { track(): void } = noopAnalytics;
   private userId: string;
   private appId: string = APP_ID;
+  private sessionId: string = uuid();
 
   constructor(userId: string) {
     this.userId = userId;
@@ -46,6 +48,13 @@ export class Analytics {
       traits = {
         ...traits,
         appId: this.appId,
+      };
+    }
+
+    if (this.sessionId) {
+      traits = {
+        ...traits,
+        sessionId: this.sessionId,
       };
     }
 

--- a/packages/shared/src/analytics/types.ts
+++ b/packages/shared/src/analytics/types.ts
@@ -9,14 +9,18 @@ export enum ANALYTICS_EVENT {
 export type ANALYTICS_EVENTS = {
   [ANALYTICS_EVENT.DOWNLOAD_VERSION]: {
     version: string;
+    os: string;
   };
   [ANALYTICS_EVENT.INSTALL_VERSION_START]: {
     version: string;
+    os: string;
   };
   [ANALYTICS_EVENT.INSTALL_VERSION_SUCCESS]: {
     version: string;
+    os: string;
   };
   [ANALYTICS_EVENT.INSTALL_VERSION_ERROR]: {
     version: string;
+    os: string;
   };
 };


### PR DESCRIPTION
This PR updates the analytics traits body to send a session id to track the events better.

It also sends the OS used.