### PR TITLE
fix: Catch download errors

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -10,6 +10,7 @@ import { getOSName, PLATFORM } from './helpers';
 // Initialize Sentry
 Sentry.init({
   dsn: 'https://47fa1e9f4bfed88d2a4b2bdd7b3d48b6@o4504361728212992.ingest.us.sentry.io/4507924285161472',
+  enabled: import.meta.env.PROD,
 });
 
 // Initialize logger

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -90,15 +90,15 @@ export async function restoreOrCreateWindow() {
   window.webContents.session.on('will-download', (_, item) => {
     activeDownloads.push(item);
     item.on('done', () => {
-      activeDownloads = activeDownloads.filter(dl => dl !== item);
+      activeDownloads = activeDownloads.filter(_item => _item !== item);
     });
   });
 
   window.on('close', _ => {
     // Cancel all active downloads
-    activeDownloads.forEach(dlItem => {
-      if (dlItem.getState() === 'progressing') {
-        dlItem.cancel();
+    activeDownloads.forEach(item => {
+      if (item.getState() === 'progressing') {
+        item.cancel();
       }
     });
   });

--- a/packages/main/src/modules/ipc.ts
+++ b/packages/main/src/modules/ipc.ts
@@ -2,7 +2,7 @@ import { join } from 'path';
 import fs from 'node:fs';
 import { spawn } from 'child_process';
 import { app, BrowserWindow, ipcMain } from 'electron';
-import { download } from 'electron-dl';
+import { CancelError, download } from 'electron-dl';
 import log from 'electron-log/main';
 import { Analytics, IPC_EVENTS, IPC_EVENT_DATA_TYPE, ANALYTICS_EVENT, IPC_HANDLERS, getErrorMessage } from '#shared';
 import { getAppBasePath, decompressFile, getOSName, isAppUpdated, PLATFORM, getAppVersion } from '../helpers';
@@ -102,8 +102,12 @@ export async function downloadExplorer(event: Electron.IpcMainInvokeEvent, url: 
       });
     }
   } catch (error) {
-    log.error('[Main Window][IPC][DownloadExplorer] Error Downloading', url, error);
-    event.sender.send(IPC_EVENTS.DOWNLOAD_STATE, { type: IPC_EVENT_DATA_TYPE.ERROR, error });
+    if (error instanceof CancelError) {
+      log.error('[Main Window][IPC][DownloadExplorer] Download Cancelled');
+    } else {
+      log.error('[Main Window][IPC][DownloadExplorer] Error Downloading', url, error);
+      event.sender.send(IPC_EVENTS.DOWNLOAD_STATE, { type: IPC_EVENT_DATA_TYPE.ERROR, error });
+    }
   }
 
   return null;

--- a/packages/main/tests/unit.spec.ts
+++ b/packages/main/tests/unit.spec.ts
@@ -22,6 +22,11 @@ vi.mock('electron', () => {
   bw.prototype.focus = vi.fn();
   bw.prototype.restore = vi.fn();
   bw.prototype.setMenuBarVisibility = vi.fn();
+  bw.prototype.webContents = {
+    session: {
+      on: vi.fn(),
+    },
+  };
 
   const app: Pick<Electron.App, 'getAppPath' | 'getPath' | 'getVersion' | 'on'> = {
     getAppPath(): string {


### PR DESCRIPTION
This PR fixes the unhandled error when closing the app with an active download.

Fixes: https://github.com/decentraland/launcher/issues/61