### PR TITLE
chore: Save launcher installer in s3

### DIFF
--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ macos-latest, windows-latest ]
-        store: [ itch.io ]
+        store: [ dcl, itch.io ]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
This PR adds the `dcl` key in the `store-release` CI to upload the vanilla installer into S3 buckets.