### PR TITLE
fix: Enhance download tracking

### DIFF
--- a/packages/main/src/index.ts
+++ b/packages/main/src/index.ts
@@ -64,6 +64,11 @@ app
   })
   .catch(e => console.error('Failed create window:', e));
 
+// Handle analytics tracking on quit
+app.on('before-quit', async () => {
+  await analytics.track(ANALYTICS_EVENT.LAUNCHER_CLOSE, { version: getAppVersion() });
+  await analytics.closeAndFlush();
+});
 /**
  * Check for app updates, install it in background and notify user that new version was installed.
  * No reason run this in non-production build.
@@ -81,6 +86,7 @@ function updateAppAndQuit() {
 
     updater.autoUpdater.on('checking-for-update', () => {
       log.info('[Main Window][AutoUpdater] Checking for updates');
+      analytics.track(ANALYTICS_EVENT.LAUNCHER_UPDATE_CHECKING);
     });
 
     updater.autoUpdater.on('update-available', info => {
@@ -102,6 +108,7 @@ function updateAppAndQuit() {
 
     updater.autoUpdater.on('update-not-available', _info => {
       log.info('[Main Window][AutoUpdater] Update not available');
+      analytics.track(ANALYTICS_EVENT.LAUNCHER_UPDATE_NOT_AVAILABLE);
       app.quit();
     });
 

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -1,12 +1,11 @@
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { app, BrowserWindow } from 'electron';
-import { initIpcHandlers } from './modules/ipc';
 import { getAppIcon, getAdditionalArguments } from './helpers';
 
-async function createWindow() {
-  initIpcHandlers();
+let activeDownloads: Electron.DownloadItem[] = [];
 
+async function createWindow() {
   const browserWindow = new BrowserWindow({
     show: false, // Use the 'ready-to-show' event to show the instantiated BrowserWindow.
     width: 1006, // 990+16 border
@@ -86,7 +85,6 @@ export async function restoreOrCreateWindow() {
   window.focus();
 
   // Listen to active downloads and cancel them when the window is closed.
-  let activeDownloads: Electron.DownloadItem[] = [];
   window.webContents.session.on('will-download', (_, item) => {
     activeDownloads.push(item);
     item.on('done', () => {

--- a/packages/main/src/modules/ipc.ts
+++ b/packages/main/src/modules/ipc.ts
@@ -58,6 +58,8 @@ export function isExplorerUpdated(event: Electron.IpcMainInvokeEvent, version: s
 }
 
 export async function downloadExplorer(event: Electron.IpcMainInvokeEvent, url: string) {
+  let version: string | undefined = 'unknown';
+
   try {
     const win = BrowserWindow.getFocusedWindow();
     if (!win) return;
@@ -65,7 +67,7 @@ export async function downloadExplorer(event: Electron.IpcMainInvokeEvent, url: 
     log.info('[Main Window][IPC][DownloadExplorer] Downloading', url);
 
     const versionPattern = new RegExp(`(^${getBucketURL()}\\/\\${RELEASE_PREFIX})\\/(v?\\d+\\.\\d+\\.\\d+-?\\w*)\\/(\\w+.zip)$`);
-    const version = url.match(versionPattern)?.[2];
+    version = url.match(versionPattern)?.[2];
 
     if (!version) {
       log.error('[Main Window][IPC][DownloadExplorer] No valid url provided');
@@ -73,6 +75,7 @@ export async function downloadExplorer(event: Electron.IpcMainInvokeEvent, url: 
         type: IPC_EVENT_DATA_TYPE.ERROR,
         error: 'No version provided',
       });
+      await analytics.track(ANALYTICS_EVENT.DOWNLOAD_VERSION_ERROR, { version, error: 'No version provided' });
       return;
     }
 
@@ -85,7 +88,7 @@ export async function downloadExplorer(event: Electron.IpcMainInvokeEvent, url: 
             type: IPC_EVENT_DATA_TYPE.START,
             progress: 0,
           });
-          analytics.track(ANALYTICS_EVENT.DOWNLOAD_VERSION, { version });
+          analytics.track(ANALYTICS_EVENT.DOWNLOAD_VERSION, { version: version as string });
         },
         onProgress: progress => {
           event.sender.send(IPC_EVENTS.DOWNLOAD_STATE, {
@@ -94,13 +97,13 @@ export async function downloadExplorer(event: Electron.IpcMainInvokeEvent, url: 
           });
         },
         onCompleted: () => {
-          event.sender.send(IPC_EVENTS.DOWNLOAD_STATE, { type: IPC_EVENT_DATA_TYPE.COMPLETED, version });
+          event.sender.send(IPC_EVENTS.DOWNLOAD_STATE, { type: IPC_EVENT_DATA_TYPE.COMPLETED, version: version as string });
+          analytics.track(ANALYTICS_EVENT.DOWNLOAD_VERSION_SUCCESS, { version: version as string });
         },
         onCancel: () => {
           event.sender.send(IPC_EVENTS.DOWNLOAD_STATE, {
             type: IPC_EVENT_DATA_TYPE.CANCELLED,
           });
-          log.error('[Main Window][IPC][DownloadExplorer] Download Cancelled');
         },
       });
       return JSON.stringify(resp);
@@ -110,13 +113,16 @@ export async function downloadExplorer(event: Electron.IpcMainInvokeEvent, url: 
         type: IPC_EVENT_DATA_TYPE.ERROR,
         error: 'No URL provided',
       });
+      await analytics.track(ANALYTICS_EVENT.DOWNLOAD_VERSION_ERROR, { version, error: 'No URL provided' });
     }
   } catch (error) {
     if (error instanceof CancelError) {
       log.error('[Main Window][IPC][DownloadExplorer] Download Cancelled');
+      await analytics.track(ANALYTICS_EVENT.DOWNLOAD_VERSION_CANCELLED, { version: version as string });
     } else {
-      log.error('[Main Window][IPC][DownloadExplorer] Error Downloading', url, error);
+      log.error('[Main Window][IPC][DownloadExplorer] Error Downloading', url, getErrorMessage(error));
       event.sender.send(IPC_EVENTS.DOWNLOAD_STATE, { type: IPC_EVENT_DATA_TYPE.ERROR, error });
+      await analytics.track(ANALYTICS_EVENT.DOWNLOAD_VERSION_ERROR, { version, error: getErrorMessage(error) });
     }
   }
 
@@ -166,7 +172,7 @@ export async function installExplorer(event: Electron.IpcMainInvokeEvent, versio
     // Delete old versions
     cleanupVersions();
   } catch (error) {
-    log.error('[Main Window][IPC][InstallExplorer] Failed to install app:', error);
+    log.error('[Main Window][IPC][InstallExplorer] Failed to install app:', getErrorMessage(error));
     event.sender.send(IPC_EVENTS.INSTALL_STATE, { type: IPC_EVENT_DATA_TYPE.ERROR, error });
     analytics.track(ANALYTICS_EVENT.INSTALL_VERSION_ERROR, { version });
   }
@@ -290,7 +296,7 @@ export async function launchExplorer(event: Electron.IpcMainInvokeEvent, version
     await analytics.track(ANALYTICS_EVENT.LAUNCH_CLIENT_SUCCESS, { version: versionData.version });
     await closeWindow();
   } catch (error) {
-    log.error('[Main Window][IPC][LaunchExplorer] Failed to launch Explorer:', error);
+    log.error('[Main Window][IPC][LaunchExplorer] Failed to launch Explorer:', getErrorMessage(error));
     event.sender.send(IPC_EVENTS.LAUNCH_EXPLORER, {
       type: IPC_EVENT_DATA_TYPE.ERROR,
       error: getErrorMessage(error),
@@ -302,8 +308,6 @@ export async function launchExplorer(event: Electron.IpcMainInvokeEvent, version
 }
 
 export function initIpcHandlers() {
-  analytics.track(ANALYTICS_EVENT.LAUNCHER_OPEN);
-
   ipcMain.handle(IPC_HANDLERS.DOWNLOAD_EXPLORER, downloadExplorer);
   ipcMain.handle(IPC_HANDLERS.INSTALL_EXPLORER, installExplorer);
   ipcMain.handle(IPC_HANDLERS.LAUNCH_EXPLORER, launchExplorer);
@@ -313,7 +317,7 @@ export function initIpcHandlers() {
 
   // Handle analytics tracking on quit
   app.on('before-quit', async () => {
-    await analytics.track(ANALYTICS_EVENT.LAUNCHER_CLOSE);
+    await analytics.track(ANALYTICS_EVENT.LAUNCHER_CLOSE, { version: getAppVersion() });
     await analytics.closeAndFlush();
   });
 }

--- a/packages/main/src/modules/ipc.ts
+++ b/packages/main/src/modules/ipc.ts
@@ -1,7 +1,7 @@
 import { join, dirname } from 'path';
 import fs from 'node:fs';
 import { spawn } from 'child_process';
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { BrowserWindow, ipcMain } from 'electron';
 import { CancelError, download } from 'electron-dl';
 import log from 'electron-log/main';
 import semver from 'semver';
@@ -314,12 +314,6 @@ export function initIpcHandlers() {
   ipcMain.handle(IPC_HANDLERS.IS_EXPLORER_INSTALLED, isExplorerInstalled);
   ipcMain.handle(IPC_HANDLERS.IS_EXPLORER_UPDATED, isExplorerUpdated);
   ipcMain.handle(IPC_HANDLERS.GET_OS_NAME, getOSName);
-
-  // Handle analytics tracking on quit
-  app.on('before-quit', async () => {
-    await analytics.track(ANALYTICS_EVENT.LAUNCHER_CLOSE, { version: getAppVersion() });
-    await analytics.closeAndFlush();
-  });
 }
 
 async function closeWindow() {

--- a/packages/main/src/modules/protocol.ts
+++ b/packages/main/src/modules/protocol.ts
@@ -23,14 +23,13 @@ export function initProtocol() {
     }
   }
 
-  app.whenReady().then(() => {
-    if (process.argv.length > 0) {
-      const url = process.argv.find(arg => arg.startsWith(`${PROTOCOL}://`));
-      if (url) {
-        handleProtocol(url);
-      }
+  // Check for protocol in argv immediately if we're already ready
+  if (app.isReady() && process.argv.length > 0) {
+    const url = process.argv.find(arg => arg.startsWith(`${PROTOCOL}://`));
+    if (url) {
+      handleProtocol(url);
     }
-  });
+  }
 
   // Windows and Linux
   app.on('second-instance', (_, argv) => {

--- a/packages/renderer/src/components/Home/Home.tsx
+++ b/packages/renderer/src/components/Home/Home.tsx
@@ -48,7 +48,7 @@ async function getLatestRelease(version?: string, isPrerelease: boolean = false)
 
     throw new Error('No asset found for your platform');
   } catch (error) {
-    log.error('[Renderer][Home][GetLatestRelease]', error);
+    log.error('[Renderer][Home][GetLatestRelease]', getErrorMessage(error));
     throw new Error('Failed to fetch latest release');
   }
 }
@@ -134,7 +134,7 @@ export const Home: React.FC = memo(() => {
           break;
         case IPC_EVENT_DATA_TYPE.ERROR:
           setError((eventData as IpcRendererEventDataError).error);
-          log.error('[Renderer][Home][HandleLaunchState]', (eventData as IpcRendererEventDataError).error);
+          log.error('[Renderer][Home][HandleLaunchState]', getErrorMessage((eventData as IpcRendererEventDataError).error));
           break;
       }
     },
@@ -173,7 +173,7 @@ export const Home: React.FC = memo(() => {
           break;
         case IPC_EVENT_DATA_TYPE.ERROR:
           setError((eventData as IpcRendererEventDataError).error);
-          log.error('[Renderer][Home][HandleInstallState]', (eventData as IpcRendererEventDataError).error);
+          log.error('[Renderer][Home][HandleInstallState]', getErrorMessage((eventData as IpcRendererEventDataError).error));
           handleRetryInstall();
           break;
       }
@@ -232,7 +232,7 @@ export const Home: React.FC = memo(() => {
         }
         case IPC_EVENT_DATA_TYPE.ERROR:
           setError((eventData as IpcRendererEventDataError).error);
-          log.error('[Renderer][Home][HandleDownloadState]', (eventData as IpcRendererEventDataError).error);
+          log.error('[Renderer][Home][HandleDownloadState]', getErrorMessage((eventData as IpcRendererEventDataError).error));
           handleRetryDownload();
           break;
       }

--- a/packages/shared/src/analytics/types.ts
+++ b/packages/shared/src/analytics/types.ts
@@ -2,19 +2,39 @@ export enum ANALYTICS_EVENT {
   LAUNCHER_OPEN = 'Launcher Open',
   LAUNCHER_CLOSE = 'Launcher Close',
   DOWNLOAD_VERSION = 'Download Version',
+  DOWNLOAD_VERSION_SUCCESS = 'Download Version Success',
   DOWNLOAD_VERSION_ERROR = 'Download Version Error',
+  DOWNLOAD_VERSION_CANCELLED = 'Download Version Cancelled',
   INSTALL_VERSION_START = 'Install Version Start',
   INSTALL_VERSION_SUCCESS = 'Install Version Success',
   INSTALL_VERSION_ERROR = 'Install Version Error',
   LAUNCH_CLIENT_START = 'Launch Client Start',
   LAUNCH_CLIENT_SUCCESS = 'Launch Client Success',
   LAUNCH_CLIENT_ERROR = 'Launch Client Error',
+  LAUNCHER_UPDATE_AVAILABLE = 'Launcher Update Available',
+  LAUNCHER_UPDATE_CANCELLED = 'Launcher Update Cancelled',
+  LAUNCHER_UPDATE_ERROR = 'Launcher Update Error',
+  LAUNCHER_UPDATE_DOWNLOADED = 'Launcher Update Downloaded',
 }
 
 export type ANALYTICS_EVENTS = {
-  [ANALYTICS_EVENT.LAUNCHER_OPEN]: Record<string, never>;
-  [ANALYTICS_EVENT.LAUNCHER_CLOSE]: Record<string, never>;
+  [ANALYTICS_EVENT.LAUNCHER_OPEN]: {
+    version: string;
+  };
+  [ANALYTICS_EVENT.LAUNCHER_CLOSE]: {
+    version: string;
+  };
   [ANALYTICS_EVENT.DOWNLOAD_VERSION]: {
+    version: string;
+  };
+  [ANALYTICS_EVENT.DOWNLOAD_VERSION_SUCCESS]: {
+    version: string;
+  };
+  [ANALYTICS_EVENT.DOWNLOAD_VERSION_ERROR]: {
+    version: string | undefined;
+    error: string;
+  };
+  [ANALYTICS_EVENT.DOWNLOAD_VERSION_CANCELLED]: {
     version: string;
   };
   [ANALYTICS_EVENT.INSTALL_VERSION_START]: {
@@ -33,6 +53,19 @@ export type ANALYTICS_EVENTS = {
     version: string;
   };
   [ANALYTICS_EVENT.LAUNCH_CLIENT_ERROR]: {
+    version: string;
+  };
+  [ANALYTICS_EVENT.LAUNCHER_UPDATE_AVAILABLE]: {
+    version: string;
+  };
+  [ANALYTICS_EVENT.LAUNCHER_UPDATE_CANCELLED]: {
+    version: string;
+  };
+  [ANALYTICS_EVENT.LAUNCHER_UPDATE_ERROR]: {
+    version: string;
+    error: string;
+  };
+  [ANALYTICS_EVENT.LAUNCHER_UPDATE_DOWNLOADED]: {
     version: string;
   };
 };

--- a/packages/shared/src/analytics/types.ts
+++ b/packages/shared/src/analytics/types.ts
@@ -11,7 +11,9 @@ export enum ANALYTICS_EVENT {
   LAUNCH_CLIENT_START = 'Launch Client Start',
   LAUNCH_CLIENT_SUCCESS = 'Launch Client Success',
   LAUNCH_CLIENT_ERROR = 'Launch Client Error',
+  LAUNCHER_UPDATE_CHECKING = 'Launcher Update Checking',
   LAUNCHER_UPDATE_AVAILABLE = 'Launcher Update Available',
+  LAUNCHER_UPDATE_NOT_AVAILABLE = 'Launcher Update Not Available',
   LAUNCHER_UPDATE_CANCELLED = 'Launcher Update Cancelled',
   LAUNCHER_UPDATE_ERROR = 'Launcher Update Error',
   LAUNCHER_UPDATE_DOWNLOADED = 'Launcher Update Downloaded',
@@ -55,9 +57,11 @@ export type ANALYTICS_EVENTS = {
   [ANALYTICS_EVENT.LAUNCH_CLIENT_ERROR]: {
     version: string;
   };
+  [ANALYTICS_EVENT.LAUNCHER_UPDATE_CHECKING]: void;
   [ANALYTICS_EVENT.LAUNCHER_UPDATE_AVAILABLE]: {
     version: string;
   };
+  [ANALYTICS_EVENT.LAUNCHER_UPDATE_NOT_AVAILABLE]: void;
   [ANALYTICS_EVENT.LAUNCHER_UPDATE_CANCELLED]: {
     version: string;
   };

--- a/packages/shared/src/helpers.ts
+++ b/packages/shared/src/helpers.ts
@@ -7,6 +7,8 @@ export function getErrorMessage(error: unknown): string {
     errorMessage = error.toString();
   } else if (typeof error === 'object' && error !== null && 'message' in error && typeof error.message === 'string') {
     errorMessage = error.message;
+  } else if (typeof error === 'string') {
+    errorMessage = error;
   } else {
     errorMessage = 'Unknown error';
   }


### PR DESCRIPTION
This PR adds new events to have a better tracking on the auto-update flow:

- LAUNCHER_UPDATE_CHECKING
- LAUNCHER_UPDATE_AVAILABLE
- LAUNCHER_UPDATE_NOT_AVAILABLE
- LAUNCHER_UPDATE_CANCELLED
- LAUNCHER_UPDATE_ERROR
- LAUNCHER_UPDATE_DOWNLOADED

It also refactors the priority of initHandlers, executing them in the `app.whenReady` callback, and improves logging messages.