### PR TITLE
fix: Reduce bundle size

### DIFF
--- a/electron-builder.cjs
+++ b/electron-builder.cjs
@@ -49,7 +49,7 @@ const config = {
     '!node_modules/date-fns/**/**',
     '!node_modules/caniuse-lite/**/**',
     '!node_modules/@emotion/**/**',
-    '!node_modules/@sentry/cli-darwin/**',
+    '!node_modules/@sentry/cli-*/**',
     '!node_modules/@sentry/react/**',
   ],
   compression: 'store',

--- a/electron-builder.cjs
+++ b/electron-builder.cjs
@@ -1,4 +1,6 @@
 const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
 
 const config = {
   productName: 'Decentraland Launcher',
@@ -8,7 +10,51 @@ const config = {
     output: 'dist',
     buildResources: 'buildResources',
   },
-  files: ['packages/**/dist/**'],
+  files: [
+    'packages/**/dist/**',
+    'package.json',
+    'node_modules/**/*',
+    '!node_modules/.bin/**',
+    '!**/*.{map,md,markdown,txt}',
+    '!**/{test,tests,example,examples,docs,doc}/**',
+    '!**/{.DS_Store,LICENSE,license,README,CHANGELOG}*',
+    '!node_modules/*/{test,tests,example,examples,docs,doc}/**',
+    '!node_modules/**/*.{md,markdown,html,txt}',
+    '!node_modules/**/*.d.ts',
+    '!node_modules/**/*.map',
+    '!node_modules/**/LICENSE*',
+    '!node_modules/**/license*',
+    '!node_modules/**/CHANGELOG*',
+    '!node_modules/**/README*',
+    '!node_modules/**/.DS_Store',
+    '!node_modules/@types/**',
+    '!node_modules/typescript/**',
+    '!node_modules/eslint*/**',
+    '!node_modules/@typescript-eslint/**',
+    '!node_modules/prettier/**',
+    '!node_modules/jest/**',
+    '!node_modules/@jest/**',
+    '!node_modules/ts-jest/**',
+    '!node_modules/vitest/**',
+    '!node_modules/happy-dom/**',
+    '!node_modules/playwright/**',
+    '!node_modules/electron/**',
+    '!node_modules/electron-builder/**',
+    '!node_modules/app-builder-*/**',
+    '!node_modules/@sentry/wizard/**',
+    '!node_modules/@babel/**/**',
+    '!node_modules/@mui/**/**',
+    '!node_modules/react-dom/**/**',
+    '!node_modules/decentraland-ui2/**/**',
+    '!node_modules/date-fns/**/**',
+    '!node_modules/caniuse-lite/**/**',
+    '!node_modules/@emotion/**/**',
+    '!node_modules/@sentry/**/**',
+    'node_modules/@sentry/electron/**',
+    'node_modules/@sentry/core/**',
+    'node_modules/@sentry/node/**',
+  ],
+  compression: 'store',
   win: {
     publisherName: 'Decentraland Foundation',
     appId: 'Decentraland.Launcher',
@@ -54,6 +100,7 @@ const config = {
   dmg: {
     title: 'Decentraland Launcher Installer',
     background: 'buildResources/background.png',
+    format: 'UDZO',
     window: {
       width: 714,
       height: 472,
@@ -84,6 +131,30 @@ const config = {
       schemes: ['decentraland'],
     },
   ],
+  afterPack: async context => {
+    if (process.platform === 'darwin' && process.env.MODE === 'production') {
+      const { appOutDir, packager } = context;
+      const appName = packager.appInfo.productFilename;
+      const appPath = path.join(appOutDir, `${appName}.app/Contents/MacOS/${appName}`);
+
+      console.log('⚙️ Stripping debug symbols...');
+      execSync(`strip "${appPath}"`);
+      console.log('✅ Debug symbols removed.');
+    }
+  },
+  afterAllArtifactBuild: async buildResult => {
+    if (process.platform === 'darwin' && process.env.MODE === 'production') {
+      const { artifactPaths } = buildResult;
+      const dmgPaths = artifactPaths.filter(path => path.endsWith('.dmg'));
+
+      for (const dmgPath of dmgPaths) {
+        console.log(`🗜️ Compressing DMG file: ${dmgPath}`);
+        const compressedPath = `${dmgPath.slice(0, -4)}-compressed.dmg`;
+        execSync(`hdiutil convert "${dmgPath}" -format UDBZ -imagekey zlib-level=9 -o "${compressedPath}"`);
+        fs.renameSync(compressedPath, dmgPath);
+      }
+    }
+  },
 };
 
 // Sign Windows .exe

--- a/packages/main/src/mainWindow.ts
+++ b/packages/main/src/mainWindow.ts
@@ -72,6 +72,8 @@ async function createWindow() {
  * Restore an existing BrowserWindow or Create a new BrowserWindow.
  */
 export async function restoreOrCreateWindow() {
+  await app.whenReady();
+
   let window = BrowserWindow.getAllWindows().find(w => !w.isDestroyed());
 
   if (window === undefined) {

--- a/packages/main/tests/unit.spec.ts
+++ b/packages/main/tests/unit.spec.ts
@@ -28,7 +28,7 @@ vi.mock('electron', () => {
     },
   };
 
-  const app: Pick<Electron.App, 'getAppPath' | 'getPath' | 'getVersion' | 'on'> = {
+  const app: Pick<Electron.App, 'getAppPath' | 'getPath' | 'getVersion' | 'on' | 'whenReady'> = {
     getAppPath(): string {
       return '';
     },
@@ -39,6 +39,7 @@ vi.mock('electron', () => {
       return '1.0.0';
     },
     on: vi.fn(),
+    whenReady: vi.fn(),
   };
 
   const ipcMain: Pick<Electron.IpcMain, 'handle'> = {


### PR DESCRIPTION
This PR reduces the installers' size by updating the compression value to `store` and removing the `node_modules/` libs not required after the building phase.

So far, this first approach has reduced the size of the MacOS installer by ~37%.

MacOS:
- arm: 127 MB-> 93 MB
- x64: 134 MB -> 97 MB

We couldn't see a significant size reduction for Windows, but it can be improved by adding more unrequired libs to the filter.

Windows:
- x64: 94.9 MB -> 89 MB

Closes: https://github.com/decentraland/launcher/issues/108