### PR TITLE
fix: Load initial screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "electron": "31.0.2",
         "electron-builder": "24.13.3",
         "eslint": "8.57.0",
+        "eslint-config-prettier": "9.1.0",
         "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-jest": "^28.6.0",
@@ -1046,6 +1047,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "electron": "31.0.2",
     "electron-builder": "24.13.3",
     "eslint": "8.57.0",
+    "eslint-config-prettier": "9.1.0",
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jest": "^28.6.0",

--- a/packages/main/src/modules/ipc.ts
+++ b/packages/main/src/modules/ipc.ts
@@ -322,11 +322,14 @@ export async function launchExplorer(event: Electron.IpcMainInvokeEvent, version
 export async function downloadLauncher(event: Electron.IpcMainInvokeEvent) {
   const osName = getOSName();
   let url = '';
+  let filename = '';
 
   if (osName === PLATFORM.MAC) {
     url = `${LAUNCHER_BASE_URL}/Decentraland_aarch64.dmg`;
+    filename = 'Decentraland.dmg';
   } else if (osName === PLATFORM.WINDOWS) {
     url = `${LAUNCHER_BASE_URL}/Decentraland_x64-setup.exe`;
+    filename = 'Decentraland.exe';
   } else {
     log.error('[Main Window][IPC][DownloadLauncher] Unsupported OS');
     return;
@@ -341,6 +344,7 @@ export async function downloadLauncher(event: Electron.IpcMainInvokeEvent) {
     if (url) {
       const resp = await download(win, url, {
         directory: getDownloadsPath(),
+        filename: filename,
         onStarted: _item => {
           event.sender.send(IPC_EVENTS.DOWNLOAD_STATE, {
             type: IPC_EVENT_DATA_TYPE.START,

--- a/packages/main/src/modules/ipc.ts
+++ b/packages/main/src/modules/ipc.ts
@@ -326,10 +326,10 @@ export async function downloadLauncher(event: Electron.IpcMainInvokeEvent) {
 
   if (osName === PLATFORM.MAC) {
     url = `${LAUNCHER_BASE_URL}/Decentraland_aarch64.dmg`;
-    filename = 'Decentraland.dmg';
+    filename = 'Decentraland_installer.dmg';
   } else if (osName === PLATFORM.WINDOWS) {
     url = `${LAUNCHER_BASE_URL}/Decentraland_x64-setup.exe`;
-    filename = 'Decentraland.exe';
+    filename = 'Decentraland_installer.exe';
   } else {
     log.error('[Main Window][IPC][DownloadLauncher] Unsupported OS');
     return;


### PR DESCRIPTION
This PR fixes the initial screen when using a Mac with an Intel chip. 

It briefly displayed the outdated notification screen, and now it must only display the download and launch flow.